### PR TITLE
Fix convert context

### DIFF
--- a/lekko_client/helpers.py
+++ b/lekko_client/helpers.py
@@ -16,8 +16,7 @@ def convert_context(context: dict) -> Dict[str, Value]:
             return Value(double_value=val)
         else:
             return Value(string_value=str(val))
-
-    return {k: convert_value(v) for k, v in context}
+    return {k: convert_value(v) for k, v in context.items()}
 
 
 class ApiKeyInterceptor(ClientInterceptor):


### PR DESCRIPTION
Was able to break the example by passing in a context:

```python
...
val = client.get_int(args.feature, {"d": 3})
...
```

and running

```bash
python3 example.py --apikey <apikey> --owner lekkodev --repo config-test --feature rules --feature-type int
```
