### PR TITLE
Fix cached git client init and decrease memory usage

### DIFF
--- a/lekko_client/clients/cached_git_client.py
+++ b/lekko_client/clients/cached_git_client.py
@@ -48,10 +48,10 @@ class CachedGitClient(CachedDistributionClient):
         credentials: grpc.ChannelCredentials = grpc.ssl_channel_credentials(),
         should_watch: Optional[bool] = True,
     ):
-        super().__init__(lekko_uri, repository_owner, repository_name, store, api_key, context, credentials)
         self.watcher: Optional[BaseObserver] = None
         self.path = path
         self.should_watch = should_watch
+        super().__init__(lekko_uri, repository_owner, repository_name, store, api_key, context, credentials)
 
     def initialize(self) -> None:
         super().initialize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: Apache Software License"]
 dynamic = ["version", "description"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   'grpcio ~= 1.32',
   'grpcio-tools ~= 1.32',

--- a/tests/clients/test_cached_git_client.py
+++ b/tests/clients/test_cached_git_client.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from watchdog.observers import Observer
 
 import lekko_client
 from lekko_client.clients.cached_git_client import CachedGitClient
@@ -12,13 +13,14 @@ from lekko_client.gen.lekko.backend.v1beta1.distribution_service_pb2 import (
 # Test that initialization doesn't cause errors
 def test_init():
     with mock.patch.object(CachedGitClient, "load_contents", lambda _: GetRepositoryContentsResponse()):
-        try:
-            lekko_client.initialize(
-                lekko_client.CachedGitConfig(
-                    owner_name="test_owner",
-                    repo_name="test_repo",
-                    git_repo_path="",
+        with mock.patch("watchdog.observers.Observer", spec_set=Observer):
+            try:
+                lekko_client.initialize(
+                    lekko_client.CachedGitConfig(
+                        owner_name="test_owner",
+                        repo_name="test_repo",
+                        git_repo_path="_test_/_path_",
+                    )
                 )
-            )
-        except Exception:
-            pytest.fail("cached git client initialization failed")
+            except Exception:
+                pytest.fail("cached git client initialization failed")

--- a/tests/clients/test_cached_git_client.py
+++ b/tests/clients/test_cached_git_client.py
@@ -1,0 +1,23 @@
+from unittest import mock
+
+import lekko_client
+import pytest
+from lekko_client.clients.cached_git_client import CachedGitClient
+from lekko_client.gen.lekko.backend.v1beta1.distribution_service_pb2 import (
+    GetRepositoryContentsResponse,
+)
+
+
+# Test that initialization doesn't cause errors
+def test_init():
+    with mock.patch.object(CachedGitClient, "load_contents", lambda _: GetRepositoryContentsResponse()):
+        try:
+            lekko_client.initialize(
+                lekko_client.CachedGitConfig(
+                    owner_name="test_owner",
+                    repo_name="test_repo",
+                    git_repo_path="",
+                )
+            )
+        except:
+            pytest.fail("cached git client initialization failed")

--- a/tests/clients/test_cached_git_client.py
+++ b/tests/clients/test_cached_git_client.py
@@ -1,7 +1,8 @@
 from unittest import mock
 
-import lekko_client
 import pytest
+
+import lekko_client
 from lekko_client.clients.cached_git_client import CachedGitClient
 from lekko_client.gen.lekko.backend.v1beta1.distribution_service_pb2 import (
     GetRepositoryContentsResponse,
@@ -19,5 +20,5 @@ def test_init():
                     git_repo_path="",
                 )
             )
-        except:
+        except Exception:
             pytest.fail("cached git client initialization failed")

--- a/tests/clients/test_cached_git_client.py
+++ b/tests/clients/test_cached_git_client.py
@@ -13,7 +13,7 @@ from lekko_client.gen.lekko.backend.v1beta1.distribution_service_pb2 import (
 # Test that initialization doesn't cause errors
 def test_init():
     with mock.patch.object(CachedGitClient, "load_contents", lambda _: GetRepositoryContentsResponse()):
-        with mock.patch("watchdog.observers.Observer", spec_set=Observer):
+        with mock.patch("lekko_client.clients.cached_git_client.Observer", spec_set=Observer):
             try:
                 lekko_client.initialize(
                     lekko_client.CachedGitConfig(


### PR DESCRIPTION
A few small fixes:
- Update pyproject to indicate min. Python version as 3.10 (pattern matching syntax)
- Fix cached git client constructor (super needs to run last)
- Reduce CPU and memory usage in events batcher
    - Added simple sampling logic after a certain size if there is a backlog of events to be processed
    - Switched to a blocking `queue.get()` to prevent busy waiting in events batcher thread
        - Stopping the events batcher thread will push a sentinel value in the queue to prevent waiting if no events are present
